### PR TITLE
Makefile cleanup

### DIFF
--- a/makefile
+++ b/makefile
@@ -19,7 +19,7 @@ libstrangle32.so:
 	$(CC) $(CFLAGS) -m32 -o libstrangle32.so libstrangle.c
 
 install: all
-	install -m 0644 libstrangle.conf $(DESTDIR)/etc/ld.so.conf.d/
+	install -m 0644 -D -T libstrangle.conf $(DESTDIR)/etc/ld.so.conf.d/libstrangle.conf
 	install -m 0755 -D -T libstrangle64.so $(DESTDIR)$(LIB32_PATH)/libstrangle.so
 	install -m 0755 -D -T libstrangle32.so $(DESTDIR)$(LIB64_PATH)/libstrangle.so
 	install -m 0755 -D -T strangle.sh $(DESTDIR)$(bindir)/strangle

--- a/makefile
+++ b/makefile
@@ -9,8 +9,8 @@ LIB64_PATH=$(libdir)/libstrangle/lib64
 all: libstrangle64.so libstrangle32.so libstrangle.conf
 
 libstrangle.conf:
-	echo "$(LIB32_PATH)/" > libstrangle.conf
-	echo "$(LIB64_PATH)/" >> libstrangle.conf
+	@echo "$(LIB32_PATH)/" > libstrangle.conf
+	@echo "$(LIB64_PATH)/" >> libstrangle.conf
 
 libstrangle64.so:
 	$(CC) $(CFLAGS) -m64 -o libstrangle64.so libstrangle.c


### PR DESCRIPTION
This pull request addresses some issues I ran into with the Makefile on Arch Linux

- ld.so.conf.d does not always exist in clean build environments. The first commit will create the directory if it does not exist in a similar manner to how the other lib* directories are created
- The calls to echo in the libstrangle.conf target will print the actual echo call to the console which can be distracting and confusing during the build process.