### PR TITLE
ArchLinux PKGBUILD

### DIFF
--- a/archlinux/.gitignore
+++ b/archlinux/.gitignore
@@ -1,0 +1,2 @@
+/libstrangle/*
+/libstrangle*pkg.tar.xz

--- a/archlinux/00-defer-ldconfig.patch
+++ b/archlinux/00-defer-ldconfig.patch
@@ -1,0 +1,12 @@
+diff --git a/makefile b/makefile
+index 4472bc7..ef41f6b 100644
+--- a/makefile
++++ b/makefile
+@@ -23,7 +23,6 @@ install: all
+ 	install -m 0755 -D -T libstrangle64.so $(DESTDIR)$(LIB32_PATH)/libstrangle.so
+ 	install -m 0755 -D -T libstrangle32.so $(DESTDIR)$(LIB64_PATH)/libstrangle.so
+ 	install -m 0755 -D -T strangle.sh $(DESTDIR)$(bindir)/strangle
+-	ldconfig
+ 
+ clean:
+ 	rm -f libstrangle64.so

--- a/archlinux/01-fix-prefix.patch
+++ b/archlinux/01-fix-prefix.patch
@@ -1,0 +1,12 @@
+diff --git a/makefile b/makefile
+index 6ae7b6a..ab05a89 100644
+--- a/makefile
++++ b/makefile
+@@ -1,6 +1,6 @@
+ CC=gcc
+ CFLAGS=-rdynamic -fPIC -D_GNU_SOURCE -shared -Wall
+-prefix=/usr/local
++prefix=/usr
+ bindir=$(prefix)/bin
+ libdir=$(prefix)/lib
+ LIB32_PATH=$(libdir)/libstrangle/lib32

--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -5,7 +5,7 @@ _gitname=libstrangle
 pkgdesc="Simple FPS Limiter"
 pkgver=r13.ad457ab
 pkgrel=1
-arch=('any')
+arch=('x86_64')
 makedepends=('gcc-multilib')
 
 depends=()

--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -6,7 +6,8 @@ pkgdesc="Simple FPS Limiter"
 pkgver=r13.ad457ab
 pkgrel=1
 arch=('any')
-makedepends=()
+makedepends=('gcc-multilib')
+
 depends=()
 optdepends=()
 provides=('libstrangle')

--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -1,0 +1,50 @@
+# Maintainer: pyamsoft <pyam(dot)soft(at)gmail(dot)com>
+
+pkgname=libstrangle-git
+_gitname=libstrangle
+pkgdesc="Simple FPS Limiter"
+pkgver=r13.ad457ab
+pkgrel=1
+arch=('any')
+makedepends=()
+depends=()
+optdepends=()
+provides=('libstrangle')
+conflicts=('libstrangle')
+license=('GPL3')
+url="https://github.com/torkel104/libstrangle.git"
+install=libstrangle.install
+source=("${_gitname}::git+${url}"
+        'libstrangle.install'
+        '00-defer-ldconfig.patch'
+        '01-fix-prefix.patch')
+sha256sums=('SKIP'
+            'db3268bccb1444d87a5216ecbf1ead656289923e599b0a883817fe52bfd0f1e7'
+            '153ca9f521f014c2cdecc13ed60b8ab57321f02032abb004cd202e8e86a39baf'
+            'bcd624c8c03ac2ab734e8e1e2678d4712d54ec721129576bc925a137898b1190')
+
+pkgver() {
+  cd "${srcdir}/${_gitname}"
+
+  # Resolve the version via git commit count
+  printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+prepare() {
+  cd "${srcdir}/${_gitname}"
+
+  # Apply patches
+
+  # Move ldconfig out of the make file, we will run it at install
+  patch -p1 -i "${srcdir}/00-defer-ldconfig.patch"
+
+  # Fix the prefix from /usr/local to /usr
+  patch -p1 -i "${srcdir}/01-fix-prefix.patch"
+}
+
+package() {
+  cd "${srcdir}/${_gitname}"
+
+  # Install to the $pkgdir as DESTDIR
+  make DESTDIR="${pkgdir}" install
+}

--- a/archlinux/libstrangle.install
+++ b/archlinux/libstrangle.install
@@ -1,0 +1,8 @@
+post_install() {
+  ldconfig
+}
+
+post_upgrade() {
+  post_install
+}
+

--- a/makefile
+++ b/makefile
@@ -19,7 +19,7 @@ libstrangle32.so:
 	$(CC) $(CFLAGS) -m32 -o libstrangle32.so libstrangle.c
 
 install: all
-	install -m 0644 libstrangle.conf $(DESTDIR)/etc/ld.so.conf.d/
+	install -m 0644 -D -T libstrangle.conf $(DESTDIR)/etc/ld.so.conf.d/libstrangle.conf
 	install -m 0755 -D -T libstrangle64.so $(DESTDIR)$(LIB32_PATH)/libstrangle.so
 	install -m 0755 -D -T libstrangle32.so $(DESTDIR)$(LIB64_PATH)/libstrangle.so
 	install -m 0755 -D -T strangle.sh $(DESTDIR)$(bindir)/strangle

--- a/makefile
+++ b/makefile
@@ -9,8 +9,8 @@ LIB64_PATH=$(libdir)/libstrangle/lib64
 all: libstrangle64.so libstrangle32.so libstrangle.conf
 
 libstrangle.conf:
-	echo "$(LIB32_PATH)/" > libstrangle.conf
-	echo "$(LIB64_PATH)/" >> libstrangle.conf
+	@echo "$(LIB32_PATH)/" > libstrangle.conf
+	@echo "$(LIB64_PATH)/" >> libstrangle.conf
 
 libstrangle64.so:
 	$(CC) $(CFLAGS) -m64 -o libstrangle64.so libstrangle.c


### PR DESCRIPTION
This pull request adds support for an ArchLinux package build and relies on the makefile changes in #2 .
The PKGBUILD is a simple bash script which automates the building and installing of libstrangle on machines running ArchLinux.

The PKGBUILD applies two seperate patches which help the install process conform more closely to the style recommended by ArchLinux.