### PR TITLE
Define a C standard to compile against, add linker flags

### DIFF
--- a/archlinux/01-fix-prefix.patch
+++ b/archlinux/01-fix-prefix.patch
@@ -1,12 +1,13 @@
 diff --git a/makefile b/makefile
-index 6ae7b6a..ab05a89 100644
+index b2817bc..961e1b0 100644
 --- a/makefile
 +++ b/makefile
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  CC=gcc
- CFLAGS=-rdynamic -fPIC -D_GNU_SOURCE -shared -Wall
+ CFLAGS=-rdynamic -fPIC -D_GNU_SOURCE -shared -Wall -std=c99
+ LDFLAGS=-Wl,-z,relro,-z,now
 -prefix=/usr/local
 +prefix=/usr
  bindir=$(prefix)/bin
  libdir=$(prefix)/lib
- LIB32_PATH=$(libdir)/libstrangle/lib32
+ DOC_PATH=$(prefix)/share/doc/libstrangle

--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -3,7 +3,7 @@
 pkgname=libstrangle-git
 _gitname=libstrangle
 pkgdesc="Simple FPS Limiter"
-pkgver=r24.8997c36
+pkgver=r31.49e5c02
 pkgrel=1
 arch=('x86_64')
 makedepends=('gcc-multilib')
@@ -22,7 +22,7 @@ source=("${_gitname}::git+${url}"
 sha256sums=('SKIP'
             'db3268bccb1444d87a5216ecbf1ead656289923e599b0a883817fe52bfd0f1e7'
             '40ca981cebef416abaa80247bc0a11b9bbf9e71e14172b178596c540aad9394b'
-            'bcd624c8c03ac2ab734e8e1e2678d4712d54ec721129576bc925a137898b1190')
+            'e42f778b669531493d5528df1848e3fc25510c472bcf56214336232d3e22507d')
 
 pkgver() {
   cd "${srcdir}/${_gitname}"

--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 CC=gcc
-CFLAGS=-rdynamic -fPIC -D_GNU_SOURCE -shared -Wall
+CFLAGS=-rdynamic -fPIC -D_GNU_SOURCE -shared -Wall -std=c99
 prefix=/usr/local
 bindir=$(prefix)/bin
 libdir=$(prefix)/lib

--- a/makefile
+++ b/makefile
@@ -1,5 +1,6 @@
 CC=gcc
 CFLAGS=-rdynamic -fPIC -D_GNU_SOURCE -shared -Wall -std=c99
+LDFLAGS=-Wl,-z,relro,-z,now
 prefix=/usr/local
 bindir=$(prefix)/bin
 libdir=$(prefix)/lib
@@ -14,10 +15,10 @@ libstrangle.conf:
 	@echo "$(LIB64_PATH)/" >> libstrangle.conf
 
 libstrangle64.so:
-	$(CC) $(CFLAGS) -m64 -o libstrangle64.so libstrangle.c
+	$(CC) $(CFLAGS) $(LDFLAGS) -m64 -o libstrangle64.so libstrangle.c
 
 libstrangle32.so:
-	$(CC) $(CFLAGS) -m32 -o libstrangle32.so libstrangle.c
+	$(CC) $(CFLAGS) $(LDFLAGS) -m32 -o libstrangle32.so libstrangle.c
 
 install: all
 	install -m 0644 -D -T libstrangle.conf $(DESTDIR)/etc/ld.so.conf.d/libstrangle.conf


### PR DESCRIPTION
This patch set explicitly defines C99 as the C standard to compile against. It also adds full relro to the project.

As a disclaimer, I do not really know what relro does, but I have heard it come up in discussions about hardening and other "good practices"

http://tk-blog.blogspot.com/2009/02/relro-not-so-well-known-memory.html