### PR TITLE
Less intrusive strangling

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ The included script strangle.sh, which installs into your PATH as just "strangle
 Examples:
 ```
 strangle 60 /path/to/game
-strangle /path/to/game FPS=24
 ```
 ### Steam
 You can use this with Steam by right-clicking on a game in your library and selecting Properties and then SET LAUNCH OPTIONS... under the General tab. In the input box type:

--- a/strangle.sh
+++ b/strangle.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ $# -eq 0 ]; then
+if [ "$#" -eq 0 ]; then
   echo "ERROR: No arguments"
   echo
   echo "strangle.sh <fps-limit> <program-to-strangle>"
@@ -12,7 +12,7 @@ fi
 
 if [ "$1" -eq "$1" ] 2>/dev/null; then
   # Check if the first command line argument is a valid number
-  FPS=$1
+  FPS="$1"
   shift
 else
   if ! [ "$FPS" -eq "$FPS" ] 2>/dev/null; then

--- a/strangle.sh
+++ b/strangle.sh
@@ -1,7 +1,12 @@
 #!/bin/sh
 
 if [ $# -eq 0 ]; then
-  echo "No arguments"
+  echo "ERROR: No arguments"
+  echo
+  echo "strangle.sh <fps-limit> <program-to-strangle>"
+  echo
+  echo "The fps-limit argument is required, and is expected to be an"
+  echo "integer value"
   exit
 fi
 

--- a/strangle.sh
+++ b/strangle.sh
@@ -1,19 +1,19 @@
 #!/bin/sh
 
 if [ $# -eq 0 ]; then
-	echo "No arguments"
-	exit
+  echo "No arguments"
+  exit
 fi
 
 if [ "$1" -eq "$1" ] 2>/dev/null; then
-	# Check if the first command line argument is a valid number
-	FPS=$1
-	shift
+  # Check if the first command line argument is a valid number
+  FPS=$1
+  shift
 else
-	if ! [ "$FPS" -eq "$FPS" ] 2>/dev/null; then
-		# Check if the environmental variable FPS is a valid number
-		FPS=0
-	fi
+  if ! [ "$FPS" -eq "$FPS" ] 2>/dev/null; then
+    # Check if the environmental variable FPS is a valid number
+    FPS=0
+  fi
 fi
 
 export FPS="${FPS}"

--- a/strangle.sh
+++ b/strangle.sh
@@ -1,37 +1,20 @@
-#!/bin/bash
+#!/bin/sh
+
 if [ $# -eq 0 ]; then
 	echo "No arguments"
 	exit
 fi
 
-# Check if the FPS= argument is given
-c=0
-for i in "$@"; do
-	case $i in
-		fps=*|FPS=*)
-			f="${i#*=}"
-			args=( "$@" )
-			unset args[c]
-			((c--))
-			set -- "${args[@]}"
-			;;
-		*)
-			;;
-	esac
-((c++))
-done
-
 if [ "$1" -eq "$1" ] 2>/dev/null; then
 	# Check if the first command line argument is a valid number
 	FPS=$1
 	shift
-elif [ "$f" -eq "$f" ] 2>/dev/null; then
-	FPS=$f
 else
 	if ! [ "$FPS" -eq "$FPS" ] 2>/dev/null; then
 		# Check if the environmental variable FPS is a valid number
 		FPS=0
 	fi
 fi
-export "FPS=${FPS}"
+
+export FPS="${FPS}"
 LD_PRELOAD="libstrangle.so:${LD_PRELOAD}" "$@"

--- a/strangle.sh
+++ b/strangle.sh
@@ -6,7 +6,8 @@ if [ "$#" -eq 0 ]; then
   echo "strangle.sh <fps-limit> <program-to-strangle>"
   echo
   echo "The fps-limit argument is required, and is expected to be an"
-  echo "integer value"
+  echo "integer value. If it is not provided, libstrangle will assume"
+  echo "there is no FPS limit"
   exit
 fi
 

--- a/strangle.sh
+++ b/strangle.sh
@@ -21,5 +21,6 @@ else
   fi
 fi
 
-export FPS="${FPS}"
-LD_PRELOAD="libstrangle.so:${LD_PRELOAD}" "$@"
+# Execute the strangled program under a clean environment
+# pass through the FPS and overriden LD_PRELOAD environment variables
+exec env FPS="${FPS}" LD_PRELOAD="libstrangle.so:${LD_PRELOAD}" "$@"


### PR DESCRIPTION
This patch removes the loop which parses arguments looking for an FPS=/fps= argument.
Other programs may accept fps=* as a valid argument, and libstrangle would eat the
argument with the loop.

By removing the loop, we are able to change a couple things:
* One is that it would allow these hypothetical programs to run correctly.
* Two is that it makes the libstrangle input more restrcitve, the FPS must be the first argument, and
   all following arguments are expected to be the program to strangle
* Three is that it allows the script to run using plain /bin/sh instead of relying on bash (and bash arrays)

The patch set also applies some other changes to the strangle script in an attempt to improve  
readability and ease of use.